### PR TITLE
backend: allow cross domain queries. wildcard CORS.

### DIFF
--- a/backend/hercules.cabal
+++ b/backend/hercules.cabal
@@ -74,6 +74,7 @@ library
                      , text
                      , time
                      , wai
+                     , wai-cors
                      , wai-extra
                      , warp
                      , wl-pprint-text

--- a/backend/src/Hercules/Lib.hs
+++ b/backend/src/Hercules/Lib.hs
@@ -15,6 +15,7 @@ import Data.Monoid                          ((<>))
 import Data.Text
 import Network.Wai
 import Network.Wai.Handler.Warp
+import Network.Wai.Middleware.Cors          (simpleCors)
 import Network.Wai.Middleware.RequestLogger
 import Safe                                 (headMay)
 import Servant
@@ -36,6 +37,7 @@ import Hercules.Query.Hydra
 import Hercules.ServerEnv
 import Hercules.Static
 
+-- | start Application. No restriction on cross-domain (CORS allow *)
 startApp :: Config -> IO ()
 startApp config = do
   let authenticators = configAuthenticatorList config
@@ -46,7 +48,7 @@ startApp config = do
     Just env -> do
       T.putStrLn $ "Serving on http://" <> configHostname config
                    <> ":" <> (pack . show $ port)
-      run port . logging =<< app env
+      run port . (logging . simpleCors) =<< app env
 
 loggingMiddleware :: Config -> Middleware
 loggingMiddleware config = case configAccessLogLevel config of


### PR DESCRIPTION
CORS is a set of rules checked by browers and application servers to retrict access to ressources by domain/@IP...
Without correct http header, the browser discard data retreived from backend.

* allow frontend to query backend whather the domain = no restriction on
domain
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS