### PR TITLE
Use webpack proxy for API access

### DIFF
--- a/frontend/default.nix
+++ b/frontend/default.nix
@@ -1,6 +1,6 @@
 { backend ? (import ./../backend {})
 , pkgs ? (import ./../pkgs.nix) {}
-, backendURL ? "http://localhost:8080" }:
+, backendURL ? "http://localhost:3000/api" }:
 
 with pkgs;
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -37,6 +37,12 @@ module.exports = {
     inline: true,
     stats: 'errors-only',
     historyApiFallback: true,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        pathRewrite: {"^/api" : ""}
+      }
+    },
     headers: {
        "Access-Control-Allow-Origin": "*",
        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",


### PR DESCRIPTION
This proxies API requests through the webpack dev server running on port 3000. This solves the CORS issue ( https://github.com/hercules-ci/hercules/pull/30 ), as now everything can be reached via the same port.

In productive development, it will be probably easiest to use e.g. nginx to do this proxying.