### PR TITLE
footer_position_fix

### DIFF
--- a/frontend/src/View.elm
+++ b/frontend/src/View.elm
@@ -47,13 +47,21 @@ viewBody model =
                     ]
                 ]
     in
+        [Options.div
+            [   Options.css "flex" "1"
+                ,Options.css "position" "absolute"
+                ,Options.css "height" "75%"
+                ,Options.css "width" "100%"
+            ]
+
+            (
         Options.div
             [ Options.css "margin" "30px"
             , Options.css "min-height" "100%"
             ]
             (pageToView model)
             :: [ Footer.mini
-                    [ Options.css "position" "absolute"
+                    [ Options.css "position" "relative"
                     , Options.css "bottom" "-70px"
                     , Options.css "width" "100%"
                     ]
@@ -73,6 +81,8 @@ viewBody model =
                             ]
                     }
                ]
+            )
+        ]    
 
 
 pageToView : AppModel -> List (Html Msg)


### PR DESCRIPTION
The previous footer used to overlap the page content when the page content overflows the window view.
This one is always stuck to the bottom of the page 